### PR TITLE
Fix dev setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, install the dependencies and then run the development server:
+
+```bash
+npm install
+```
+
+Then start the server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- add explicit `npm install` step to the frontend README

## Testing
- `npm install`
- `npm run build:parser`
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684d3621bab48322bc1858153561cfb0