### PR TITLE
Add Monaco editor UI

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -166,3 +166,6 @@ a.secondary {
     filter: invert();
   }
 }
+
+.editor { height: 80vh; border: 1px solid #ccc; }
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,95 +1,16 @@
-import Image from "next/image";
-import styles from "./page.module.css";
+'use client';
+import dynamic from 'next/dynamic';
+import styles from './page.module.css';
+
+const DawEditor = dynamic(() => import('../components/DawEditor'), { ssr: false });
 
 export default function Home() {
   return (
     <div className={styles.page}>
       <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
-        </div>
+        <h1>dawntone editor</h1>
+        <DawEditor />
       </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }

--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Editor from '@monaco-editor/react';
+import { useEffect, useState } from 'react';
+
+export default function DawEditor() {
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('daw-src');
+    if (stored) setCode(stored);
+  }, []);
+
+  const handleChange = (value?: string) => {
+    const v = value ?? '';
+    setCode(v);
+    localStorage.setItem('daw-src', v);
+  };
+
+  return (
+    <Editor
+      className="editor"
+      height="80vh"
+      defaultLanguage="plaintext"
+      value={code}
+      onChange={handleChange}
+      options={{ automaticLayout: true }}
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "fs": "^0.0.1-security",
+        "monaco-editor": "^0.45.0",
         "next": "15.3.3",
         "pegjs": "^0.10.0",
         "react": "^19.0.0",
@@ -428,6 +430,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.3.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.3.tgz",
@@ -719,6 +744,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/monaco-editor": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
+      "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -937,6 +968,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,18 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "fs": "^0.0.1-security",
+    "monaco-editor": "^0.45.0",
+    "next": "15.3.3",
     "pegjs": "^0.10.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^19",
-    "@types/react-dom": "^19"
+    "@types/react-dom": "^19",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add `@monaco-editor/react` and `monaco-editor` dependencies
- create client component `DawEditor` that persists changes to localStorage
- display `DawEditor` in the homepage

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*


------
https://chatgpt.com/codex/tasks/task_e_684d55ff36c88322846e3abe12fcfd8d