### PR TITLE
Fix 404 by loading Monaco from CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .next/
 app/*.ico
+public/vs/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@
 | 対応ブラウザ | Chrome / Firefox / Edge / Safari（モバイル含む） |
 | デプロイ | Vercel, localhost:3000 でも動作 |
 
+### Monaco Editor について
+
+Monaco のアセットはリポジトリには含めず、CDN から読み込みます。オンライン環境でそのまま利用できますが、オフラインでは動作しません。
+
 
 ## 🛠 環境構築
 

--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -1,6 +1,13 @@
 'use client';
-import Editor from '@monaco-editor/react';
+import Editor, { loader } from '@monaco-editor/react';
 import { useEffect, useState } from 'react';
+
+// Load Monaco editor resources from CDN to avoid bundling large files
+loader.config({
+  paths: {
+    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs',
+  },
+});
 
 export default function DawEditor() {
   const [code, setCode] = useState('');


### PR DESCRIPTION
## Summary
- configure Monaco loader to use CDN resources
- document Monaco CDN approach in README
- ignore optional local `public/vs` folder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d5fb3a070832292ae7f82259817b7