### PR TITLE
Improve Monaco local install workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,17 @@
 
 ### Monaco Editor について
 
-Monaco のアセットはリポジトリには含めず、CDN から読み込みます。オンライン環境でそのまま利用できますが、オフラインでは動作しません。
+Monaco のアセットは npm インストール時に自動的に `public/vs` へコピーされ、アプリは `/vs` から読み込みます。オフライン環境でも動作します。
+
+もし `vs/*` の取得で 404 エラーが出る場合は、`public/vs` フォルダが存在するか確認してください。`npm install` を実行すると `postinstall` スクリプトによって自動作成されます。
+
+Network タブで `loader.js` などが 200 で返るかどうかを確認すると原因の特定に役立ちます。
 
 
 ## 🛠 環境構築
 
 1. Node.js 18 以上をインストール
-2. ルートディレクトリで `npm install`
-3. `npm run build:parser` で PEG.js のパーサーを生成
-4. `npm test` でサンプル `.daw` ファイルがパースできるか確認
-5. `npm run dev` を実行し http://localhost:3000 を開く
+2. `npm run deploy` を実行して依存関係のインストールとビルドを行う
+3. `npm test` でサンプル `.daw` ファイルがパースできるか確認
+4. `npm run dev` を実行し http://localhost:3000 を開く
 

--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -2,10 +2,10 @@
 import Editor, { loader } from '@monaco-editor/react';
 import { useEffect, useState } from 'react';
 
-// Load Monaco editor resources from CDN to avoid bundling large files
+// Load Monaco editor resources from the local public directory
 loader.config({
   paths: {
-    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs',
+    vs: '/vs',
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "daw",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "deploy": "npm ci && npm run build:parser && npm run build",
+    "postinstall": "node scripts/copy-monaco.js"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/scripts/copy-monaco.js
+++ b/scripts/copy-monaco.js
@@ -1,0 +1,22 @@
+import { cp } from 'fs/promises';
+import { existsSync } from 'fs';
+
+const src = 'node_modules/monaco-editor/min/vs';
+const dest = 'public/vs';
+
+async function main() {
+  try {
+    if (existsSync(src)) {
+      await cp(src, dest, { recursive: true });
+      console.log('Monaco assets copied to', dest);
+    } else {
+      console.error('Monaco editor not installed.');
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error('Failed to copy Monaco assets:', err);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- copy Monaco assets to `public/vs` after `npm install`
- load Monaco from `/vs`
- add deploy script
- update docs for new workflow

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d6d4167008322bd258872341806c6