### PR TITLE
Fix Monaco asset path for Vercel

### DIFF
--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -2,10 +2,13 @@
 import Editor, { loader } from '@monaco-editor/react';
 import { useEffect, useState } from 'react';
 
+// Determine Monaco asset path from environment variable or fallback
+const monacoPath = process.env.NEXT_PUBLIC_MONACO_PATH ?? '/vs';
+
 // Load Monaco editor resources from the local public directory
 loader.config({
   paths: {
-    vs: '/vs',
+    vs: monacoPath,
   },
 });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
+  webpack(config) {
+    config.resolve.alias["vs"] = path.join(__dirname, "public/vs");
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "public": true,
+  "cleanUrls": true,
+  "build": {
+    "env": {
+      "NEXT_PUBLIC_MONACO_PATH": "/vs"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to ensure `/vs` assets are available on Vercel
- alias `vs` path in `next.config.ts`
- read `NEXT_PUBLIC_MONACO_PATH` env in `DawEditor`

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: asks for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684ddef654888322ac989f2cd8b59136