### PR TITLE
Implement autosave to localStorage

### DIFF
--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Editor, { loader } from '@monaco-editor/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 // Determine Monaco asset path from environment variable or fallback
 const monacoPath = process.env.NEXT_PUBLIC_MONACO_PATH ?? '/vs';
@@ -14,16 +14,27 @@ loader.config({
 
 export default function DawEditor() {
   const [code, setCode] = useState('');
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const stored = localStorage.getItem('daw-src');
     if (stored) setCode(stored);
   }, []);
 
+  useEffect(() => {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      localStorage.setItem('daw-src', code);
+    }, 300);
+
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, [code]);
+
   const handleChange = (value?: string) => {
     const v = value ?? '';
     setCode(v);
-    localStorage.setItem('daw-src', v);
   };
 
   return (


### PR DESCRIPTION
## Summary
- auto-save Monaco editor contents to `localStorage`

## Testing
- `npm test`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_684e61cece00832290516da9f5ed38ea