### PR TITLE
Implement dawrun CLI parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,13 @@ Network タブで `loader.js` などが 200 で返るかどうかを確認する
 3. `npm test` でサンプル `.daw` ファイルがパースできるか確認
 4. `npm run dev` を実行し http://localhost:3000 を開く
 
+## CLI 利用方法
+
+グローバルインストールせずに `npx` から実行できます。
+
+```bash
+npx dawrun parse <path/to/file.daw>
+```
+
+指定した `.daw` ファイルを解析し、AST(JSON) を標準出力に出力します。
+

--- a/bin/dawrun.js
+++ b/bin/dawrun.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import peg from 'pegjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const grammarPath = join(__dirname, '..', 'daw_language_grammar.pegjs');
+const grammar = fs.readFileSync(grammarPath, 'utf8');
+const parser = peg.generate(grammar);
+
+function printUsage() {
+  console.log(`Usage: dawrun parse <file>`);
+}
+
+async function main() {
+  const [cmd, filePath] = process.argv.slice(2);
+  if (!cmd || cmd === '-h' || cmd === '--help') {
+    printUsage();
+    return;
+  }
+
+  if (cmd !== 'parse') {
+    console.error(`Unknown command: ${cmd}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!filePath) {
+    console.error('No input file specified.');
+    printUsage();
+    process.exit(1);
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const ast = parser.parse(content);
+    console.log(JSON.stringify(ast, null, 2));
+  } catch (err) {
+    console.error('Parse failed:', err.message);
+    process.exit(1);
+  }
+}
+
+main();
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "",
   "type": "module",
   "main": "daw_language_grammar.js",
+  "bin": {
+    "dawrun": "bin/dawrun.js"
+  },
   "scripts": {
     "build:parser": "pegjs -o daw_language_grammar.js daw_language_grammar.pegjs",
     "test": "node daw_parser_test.js",


### PR DESCRIPTION
## Summary
- implement `dawrun` CLI with `parse` command
- expose CLI binary in package.json
- document usage in README

## Testing
- `npm test`
- `node bin/dawrun.js parse example.daw`

------
https://chatgpt.com/codex/tasks/task_e_684e623333b88322be33bfb81f626b0e