### PR TITLE
Add JSON export button

### DIFF
--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -37,14 +37,34 @@ export default function DawEditor() {
     setCode(v);
   };
 
+  const handleExport = async () => {
+    const mod = await import('../daw_language_grammar.js');
+    const parser = (mod.default ?? mod).parse;
+    try {
+      const ast = parser(code);
+      const blob = new Blob([JSON.stringify(ast, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'daw.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      alert('Parse error: ' + err.message);
+    }
+  };
+
   return (
-    <Editor
-      className="editor"
-      height="80vh"
-      defaultLanguage="plaintext"
-      value={code}
-      onChange={handleChange}
-      options={{ automaticLayout: true }}
-    />
+    <div>
+      <Editor
+        className="editor"
+        height="80vh"
+        defaultLanguage="plaintext"
+        value={code}
+        onChange={handleChange}
+        options={{ automaticLayout: true }}
+      />
+      <button onClick={handleExport}>Export JSON</button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add export button to parse current editor content into JSON
- support in-browser parsing using the PEG.js grammar

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e63402f40832287192d932799c475