### PR TITLE
Add MIDI export support

### DIFF
--- a/components/DawEditor.tsx
+++ b/components/DawEditor.tsx
@@ -58,6 +58,26 @@ export default function DawEditor() {
     }
   };
 
+  const handleExportMidi = async () => {
+    const mod = await import('../daw_language_grammar.js');
+    const parser = (mod.default ?? mod).parse;
+    try {
+      const ast = parser(code);
+      const midiMod = await import('../jsonToMidi.js');
+      const midi = midiMod.createMidiFromAst(ast);
+      const uint8 = midi.toArray();
+      const blob = new Blob([uint8], { type: 'audio/midi' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'daw.mid';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      alert('Export error: ' + err.message);
+    }
+  };
+
   const createTonePartFromTrack = (track: any, key: string, baseVelocity = 90) => {
     const events: any[] = [];
 
@@ -155,6 +175,7 @@ export default function DawEditor() {
           <input type="checkbox" checked={loop} onChange={() => setLoop(!loop)} /> Loop
         </label>
         <button onClick={handleExport}>Export JSON</button>
+        <button onClick={handleExportMidi}>Export MIDI</button>
       </div>
     </div>
   );

--- a/jsonToMidi.js
+++ b/jsonToMidi.js
@@ -1,0 +1,63 @@
+import { Midi } from '@tonejs/midi';
+import * as Tone from 'tone';
+
+export function createMidiFromAst(ast) {
+  const key = ast.headers.find(h => h.key === 'key')?.val || 'C_major';
+  const tempo = parseInt(ast.headers.find(h => h.key === 'tempo')?.val || '120', 10);
+  const baseVelocity = parseInt(ast.headers.find(h => h.key === 'velocity')?.val || '90', 10);
+
+  const midi = new Midi();
+  midi.header.setTempo(tempo);
+
+  for (const track of ast.tracks) {
+    const midiTrack = midi.addTrack();
+    midiTrack.name = track.name;
+
+    for (const line of track.lines) {
+      const timeBeats = (line.bar - 1) * 4 + line.beat;
+      const durationBeats = durationToBeats(line.duration);
+      const timeSec = timeBeats * (60 / tempo);
+      const durSec = durationBeats * (60 / tempo);
+      const velocity = (line.velocity ?? baseVelocity) / 127;
+
+      if (line.type === 'note') {
+        if (line.note === 'x') continue;
+        const midiNote = scaleDegreeToMidi(line.note, key, line.octave);
+        midiTrack.addNote({ midi: midiNote, time: timeSec, duration: durSec, velocity });
+      } else if (line.type === 'chord') {
+        for (const n of line.notes) {
+          const midiNote = scaleDegreeToMidi(n, key, line.octave);
+          midiTrack.addNote({ midi: midiNote, time: timeSec, duration: durSec, velocity });
+        }
+      }
+    }
+  }
+
+  return midi;
+}
+
+function durationToBeats(dur) {
+  const map = {
+    '1m': 4,
+    '2n': 2,
+    '4n': 1,
+    '8n': 0.5,
+    '16n': 0.25
+  };
+  return map[dur] ?? 1;
+}
+
+function scaleDegreeToMidi(degree, key, octave) {
+  const scaleMap = {
+    C_major: ['C', 'D', 'E', 'F', 'G', 'A', 'B'],
+    A_minor: ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+  };
+  const scale = scaleMap[key] ?? scaleMap['C_major'];
+  let raw = degree.toString();
+  let accidental = '';
+  if (raw.includes('#')) accidental = '#';
+  if (raw.includes('b')) accidental = 'b';
+  const base = parseInt(raw[0], 10) - 1;
+  const note = scale[base] + accidental;
+  return Tone.Frequency(`${note}${octave}`).toMidi();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@tonejs/midi": "^2.0.28",
         "fs": "^0.0.1-security",
         "monaco-editor": "^0.45.0",
         "next": "15.3.3",
@@ -616,6 +617,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tonejs/midi": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@tonejs/midi/-/midi-2.0.28.tgz",
+      "integrity": "sha512-RII6YpInPsOZ5t3Si/20QKpNqB1lZ2OCFJSOzJxz38YdY/3zqDr3uaml4JuCWkdixuPqP1/TBnXzhQ39csyoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^3.0.0",
+        "midi-file": "^1.2.2"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
@@ -645,6 +656,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
     },
     "node_modules/automation-events": {
       "version": "7.1.11",
@@ -770,6 +787,12 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/midi-file": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/midi-file/-/midi-file-1.2.4.tgz",
+      "integrity": "sha512-B5SnBC6i2bwJIXTY9MElIydJwAmnKx+r5eJ1jknTLetzLflEl0GWveuBB6ACrQpecSRkOB6fhTx1PwXk2BVxnA==",
+      "license": "MIT"
     },
     "node_modules/monaco-editor": {
       "version": "0.45.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@tonejs/midi": "^2.0.28",
     "fs": "^0.0.1-security",
     "monaco-editor": "^0.45.0",
     "next": "15.3.3",


### PR DESCRIPTION
## Summary
- add `@tonejs/midi` dependency
- implement converter from DAW AST to MIDI (`jsonToMidi.js`)
- allow exporting MIDI from the editor

## Testing
- `npm test`
- `npm run lint` *(fails: Next.js ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684e81ca2d408322ac0457d73756a461